### PR TITLE
Fix regex compilation for AOT

### DIFF
--- a/DateExtractor/DateExtractor.cs
+++ b/DateExtractor/DateExtractor.cs
@@ -184,7 +184,7 @@ namespace DateExtractor
 
                 compiled.Add(new PatternEntry(
                     new Regex(p.Regex,
-                        RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                        RegexOptions.IgnoreCase),
                     fmts));
             }
 

--- a/DateExtractor/TextCleaner.cs
+++ b/DateExtractor/TextCleaner.cs
@@ -18,8 +18,8 @@ namespace DateExtractor
     /// </summary>
     internal sealed class TextCleaner
     {
-        private static readonly Regex TabsAndNewlines = new(@"[\t\r\n]+", RegexOptions.Compiled);
-        private static readonly Regex MultiSpaces = new(@"\s{2,}", RegexOptions.Compiled);
+        private static readonly Regex TabsAndNewlines = new(@"[\t\r\n]+");
+        private static readonly Regex MultiSpaces = new(@"\s{2,}");
         private readonly Regex? _ordinalRegex;
 
         private readonly Regex? _delimRegex;   // null → no delimiter replacement
@@ -55,13 +55,13 @@ namespace DateExtractor
                 patternSb.Append('-');          // hyphen as *last* char = literal
 
             patternSb.Append(']');
-            _delimRegex = new Regex(patternSb.ToString(), RegexOptions.Compiled);
+            _delimRegex = new Regex(patternSb.ToString());
 
             if (ordinals is { Length: > 0 })
             {
                 var alternation = string.Join('|', ordinals.Select(Regex.Escape));
                 _ordinalRegex = new Regex($@"(?<=\d)\s*({alternation})\b",
-                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                    RegexOptions.IgnoreCase);
             }
         }
 


### PR DESCRIPTION
## Summary
- remove `RegexOptions.Compiled` to avoid runtime code generation
- helps DateExtractor run in .NET MAUI AOT environments

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880b836d5ec832490712c5456c427c3